### PR TITLE
Update .readthedocs.yml for new requirement

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,8 @@
 ################################################################################
 
 version: 2
+sphinx:
+  configuration: doc/conf.py
 build:
   os: ubuntu-22.04
   apt_packages:


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/