### PR TITLE
Update Rust version for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,7 +23,7 @@ build:
     - pdf2svg  # For sphinxcontrib-tikz
   tools:
     python: "3.12"
-    rust: "1.75"
+    rust: "1.86"
 
 python:
   install:


### PR DESCRIPTION
The previous version was unable to read Cargo.lock. Update to 1.86, which is the latest supported by RTD.